### PR TITLE
Remove Optional usage for userId in FeignUserInterceptor and UserContext

### DIFF
--- a/src/main/java/school/faang/user_service/client/FeignUserInterceptor.java
+++ b/src/main/java/school/faang/user_service/client/FeignUserInterceptor.java
@@ -5,8 +5,6 @@ import feign.RequestTemplate;
 import lombok.RequiredArgsConstructor;
 import school.faang.user_service.config.context.UserContext;
 
-import java.util.Optional;
-
 @RequiredArgsConstructor
 public class FeignUserInterceptor implements RequestInterceptor {
 
@@ -14,7 +12,6 @@ public class FeignUserInterceptor implements RequestInterceptor {
 
     @Override
     public void apply(RequestTemplate template) {
-        Optional<Long> userId = userContext.getUserId();
-        userId.ifPresent(value -> template.header("x-user-id", String.valueOf(value)));
+        template.header("x-user-id", String.valueOf(userContext.getUserId()));
     }
 }

--- a/src/main/java/school/faang/user_service/config/context/UserContext.java
+++ b/src/main/java/school/faang/user_service/config/context/UserContext.java
@@ -2,8 +2,6 @@ package school.faang.user_service.config.context;
 
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Component
 public class UserContext {
 
@@ -13,8 +11,8 @@ public class UserContext {
         userIdHolder.set(userId);
     }
 
-    public Optional<Long> getUserId() {
-        return Optional.ofNullable(userIdHolder.get());
+    public long getUserId() {
+        return userIdHolder.get();
     }
 
     public void clear() {


### PR DESCRIPTION
В прошлых ветках я добавил `Optional` к Feign, где проверялся `x-user-id`, типа "пофиксил". Сейчас разобрался, в чем была моя ошибка, возвращаю обратно