### PR TITLE
HOTFIX: failing tests for Murzin34 due to SkillMapper

### DIFF
--- a/src/main/java/school/faang/user_service/mapper/SkillMapperCustom.java
+++ b/src/main/java/school/faang/user_service/mapper/SkillMapperCustom.java
@@ -1,0 +1,22 @@
+package school.faang.user_service.mapper;
+
+import org.springframework.stereotype.Component;
+import school.faang.user_service.dto.SkillDto;
+import school.faang.user_service.entity.Skill;
+
+@Component
+public class SkillMapperCustom {
+    public SkillDto toDto(Skill skill) {
+        return SkillDto.builder()
+                .id(skill.getId())
+                .title(skill.getTitle())
+                .build();
+    }
+
+    public Skill toEntity(SkillDto skillDto) {
+        return Skill.builder()
+                .id(skillDto.getId())
+                .title(skillDto.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/school/faang/user_service/mapper/event/EventMapper.java
+++ b/src/main/java/school/faang/user_service/mapper/event/EventMapper.java
@@ -7,14 +7,14 @@ import school.faang.user_service.dto.event.EventDto;
 import school.faang.user_service.entity.Skill;
 import school.faang.user_service.entity.User;
 import school.faang.user_service.entity.event.Event;
-import school.faang.user_service.mapper.SkillMapper;
+import school.faang.user_service.mapper.SkillMapperCustom;
 
 import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class EventMapper {
-    private final SkillMapper skillMapper;
+    private final SkillMapperCustom skillMapper;
 
     public EventDto toDto(Event event) {
         Long ownerId = event.getOwner().getId();

--- a/src/test/java/school/faang/user_service/mapper/SkillMapperTest.java
+++ b/src/test/java/school/faang/user_service/mapper/SkillMapperTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ExtendWith(MockitoExtension.class)
 class SkillMapperTest {
     @InjectMocks
-    private SkillMapper skillCustomMapper;
+    private SkillMapperCustom skillMapperCustom;
     private TestDataEvent testDataEvent;
     private Skill skill;
     private SkillDto skillDto;
@@ -30,7 +30,7 @@ class SkillMapperTest {
         skill = testDataEvent.getSkill1();
         skillDto = new SkillDto();
 
-        skillDto = skillCustomMapper.toDto(skill);
+        skillDto = skillMapperCustom.toDto(skill);
 
         assertNotNull(skillDto);
         assertThat(skillDto).usingRecursiveComparison()
@@ -43,7 +43,7 @@ class SkillMapperTest {
         skill = new Skill();
         skillDto = testDataEvent.getSkillDto1();
 
-        skill = skillCustomMapper.toEntity(skillDto);
+        skill = skillMapperCustom.toEntity(skillDto);
 
         assertNotNull(skill);
         assertThat(skill).usingRecursiveComparison()

--- a/src/test/java/school/faang/user_service/mapper/event/EventMapperTest.java
+++ b/src/test/java/school/faang/user_service/mapper/event/EventMapperTest.java
@@ -10,7 +10,7 @@ import school.faang.user_service.dto.SkillDto;
 import school.faang.user_service.dto.event.EventDto;
 import school.faang.user_service.entity.Skill;
 import school.faang.user_service.entity.event.Event;
-import school.faang.user_service.mapper.SkillMapper;
+import school.faang.user_service.mapper.SkillMapperCustom;
 import school.faang.user_service.test_data.event.TestDataEvent;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class EventMapperTest {
     @Mock
-    private SkillMapper skillCustomMapper;
+    private SkillMapperCustom skillCustomMapper;
     @InjectMocks
     private EventMapper eventCustomMapper;
     private TestDataEvent testDataEvent;


### PR DESCRIPTION
Added initial implementation from Murzin34 for SkillMapper, renamed to SkillMapperCustom to eliminate the naming conflict with Alginin.