### PR TITLE
fix - event controller fix

### DIFF
--- a/src/main/java/school/faang/user_service/controller/event/EventController.java
+++ b/src/main/java/school/faang/user_service/controller/event/EventController.java
@@ -52,7 +52,7 @@ public class EventController {
         return eventService.updateEvent(event);
     }
 
-    @GetMapping("{userId}")
+    @GetMapping("/by-user/{userId}")
     public ResponseEntity<List<EventDto>> getOwnedEvents(@RequestBody @NotNull @PathVariable Long userId) {
         return eventService.getOwnedEvents(userId);
     }


### PR DESCRIPTION
    Два маппинга конфликтовали друг с дургом
    @GetMapping("{eventId}")
    public ResponseEntity<EventDto> getEvent(@RequestBody @NotNull @PathVariable Long eventId) {
        return eventService.getEvent(eventId);
    }
    
    @GetMapping("/{userId}")
    public ResponseEntity<List<EventDto>> getOwnedEvents(@RequestBody @NotNull @PathVariable Long userId) {
        return eventService.getOwnedEvents(userId);
    }