### PR TITLE
Фикс сущности пользователя

### DIFF
--- a/src/main/java/school/faang/user_service/controller/UserV1Controller.java
+++ b/src/main/java/school/faang/user_service/controller/UserV1Controller.java
@@ -39,7 +39,7 @@ public class UserV1Controller {
     private final UserDeactivationService userDeactivationService;
     private final UserService userService;
 
-    @GetMapping("/subscription/{userId}")
+    @GetMapping("/{userId}")
     public UserSubResponseDto getUser(@Positive @PathVariable long userId) {
         return userService.getUserDtoById(userId);
     }

--- a/src/main/java/school/faang/user_service/entity/User.java
+++ b/src/main/java/school/faang/user_service/entity/User.java
@@ -16,6 +16,7 @@ import school.faang.user_service.entity.goal.GoalInvitation;
 import school.faang.user_service.entity.event.Rating;
 import school.faang.user_service.entity.premium.Premium;
 import school.faang.user_service.entity.recommendation.Language;
+import school.faang.user_service.entity.recommendation.LanguageConverter;
 import school.faang.user_service.entity.recommendation.Recommendation;
 
 import java.time.LocalDateTime;
@@ -146,7 +147,7 @@ public class User {
     @OneToOne(mappedBy = "user")
     private Premium premium;
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = LanguageConverter.class)
     @Column(name = "locale", nullable = false)
     private Language locale;
 

--- a/src/main/java/school/faang/user_service/entity/recommendation/LanguageConverter.java
+++ b/src/main/java/school/faang/user_service/entity/recommendation/LanguageConverter.java
@@ -1,0 +1,29 @@
+package school.faang.user_service.entity.recommendation;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class LanguageConverter implements AttributeConverter<Language, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Language language) {
+        if (language == null) {
+            return null;
+        }
+        return language.getTag();
+    }
+
+    @Override
+    public Language convertToEntityAttribute(String tag) {
+        if (tag == null) {
+            return null;
+        }
+        for (Language language : Language.values()) {
+            if (language.getTag().equals(tag)) {
+                return language;
+            }
+        }
+        throw new IllegalArgumentException("Unknown tag: " + tag);
+    }
+}


### PR DESCRIPTION
Был баг связанный с локалью (конкретно из-за того, что в перечислении Language используется строковое представление для значений, но аннотация @Enumerated(EnumType.STRING) ожидала, что значения будут совпадать с именами констант перечисления). Изменил на @Convert и сделал конвертер, теперь все взлетает (протестил на ендпоинте получения пользователя который до фикса не работал).