### PR TITLE
Bjs2 41467 user service

### DIFF
--- a/src/main/java/school/faang/user_service/config/redis/RedisConfiguration.java
+++ b/src/main/java/school/faang/user_service/config/redis/RedisConfiguration.java
@@ -75,4 +75,9 @@ public class RedisConfiguration {
     public ChannelTopic mentorshipOfferedTopic() {
         return new ChannelTopic(redisProperties.getChannels().getMentorshipOfferedChannel().getName());
     }
+
+    @Bean
+    public ChannelTopic  profileViewTopic() {
+        return new ChannelTopic(redisProperties.getChannels().getProfileViewChannel().getName());
+    }
 }

--- a/src/main/java/school/faang/user_service/config/redis/RedisProperties.java
+++ b/src/main/java/school/faang/user_service/config/redis/RedisProperties.java
@@ -17,6 +17,7 @@ public class RedisProperties {
     protected static class Channels {
         private Channel userBanChannel;
         private Channel mentorshipOfferedChannel;
+        private Channel profileViewChannel;
 
         @Getter
         @Setter

--- a/src/main/java/school/faang/user_service/controller/user/UserController.java
+++ b/src/main/java/school/faang/user_service/controller/user/UserController.java
@@ -15,6 +15,7 @@ import school.faang.user_service.publisher.mentorshipoffered.ProfileViewEventPub
 import school.faang.user_service.service.user.UserService;
 import school.faang.user_service.utilities.UrlUtils;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,7 +30,7 @@ public class UserController {
     @GetMapping(UrlUtils.ID)
     public UserDto getUser(@PathVariable("id") @Min(1) Long id, @RequestParam("idRequester") @Min(1) Long idRequester) {
         if (!Objects.equals(id, idRequester)) {
-            profileViewEventPublisher.publish(new ProfileViewEvent(idRequester, id));
+            profileViewEventPublisher.publish(new ProfileViewEvent(idRequester, id, LocalDateTime.now()));
         }
         return userService.getUser(id);
     }

--- a/src/main/java/school/faang/user_service/controller/user/UserController.java
+++ b/src/main/java/school/faang/user_service/controller/user/UserController.java
@@ -6,21 +6,17 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import school.faang.user_service.dto.ProfileViewEvent;
 import school.faang.user_service.dto.user.UserAvatarSize;
 import school.faang.user_service.dto.user.UserDto;
+import school.faang.user_service.publisher.mentorshipoffered.ProfileViewEventPublisher;
 import school.faang.user_service.service.user.UserService;
 import school.faang.user_service.utilities.UrlUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 @Validated
 @RestController
@@ -28,9 +24,13 @@ import java.util.List;
 @RequestMapping(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS)
 public class UserController {
     private final UserService userService;
+    private final ProfileViewEventPublisher profileViewEventPublisher;
 
     @GetMapping(UrlUtils.ID)
-    public UserDto getUser(@PathVariable("id") @Min(1) Long id) {
+    public UserDto getUser(@PathVariable("id") @Min(1) Long id, @RequestParam("idRequester") @Min(1) Long idRequester) {
+        if (!Objects.equals(id, idRequester)) {
+            profileViewEventPublisher.publish(new ProfileViewEvent(idRequester, id));
+        }
         return userService.getUser(id);
     }
 

--- a/src/main/java/school/faang/user_service/dto/ProfileViewEvent.java
+++ b/src/main/java/school/faang/user_service/dto/ProfileViewEvent.java
@@ -1,4 +1,6 @@
 package school.faang.user_service.dto;
 
-public record ProfileViewEvent(long idRequester, long idUser) {
+import java.time.LocalDateTime;
+
+public record ProfileViewEvent(long idRequester, long idUser, LocalDateTime createdTime) {
 }

--- a/src/main/java/school/faang/user_service/dto/ProfileViewEvent.java
+++ b/src/main/java/school/faang/user_service/dto/ProfileViewEvent.java
@@ -1,0 +1,4 @@
+package school.faang.user_service.dto;
+
+public record ProfileViewEvent(long idRequester, long idUser) {
+}

--- a/src/main/java/school/faang/user_service/publisher/mentorshipoffered/ProfileViewEventPublisher.java
+++ b/src/main/java/school/faang/user_service/publisher/mentorshipoffered/ProfileViewEventPublisher.java
@@ -1,0 +1,22 @@
+package school.faang.user_service.publisher.mentorshipoffered;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+import school.faang.user_service.dto.ProfileViewEvent;
+import school.faang.user_service.publisher.MessagePublisher;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileViewEventPublisher implements MessagePublisher<ProfileViewEvent> {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChannelTopic profileViewTopic;
+
+    @Override
+    public void publish(ProfileViewEvent message) {
+        redisTemplate.convertAndSend(profileViewTopic.getTopic(), message);
+
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,10 @@ spring:
           name: user_ban_channel
         mentorshipOfferedChannel:
           name: mentorship_offered_channel
+        profileViewChannel:
+          name: profile_view_event_channel
+
+
 
 services:
   s3:

--- a/src/test/java/school/faang/user_service/controller/user/UserControllerTest.java
+++ b/src/test/java/school/faang/user_service/controller/user/UserControllerTest.java
@@ -85,7 +85,7 @@ public class UserControllerTest {
 
     @Test
     void getUserSuccessTest() throws Exception {
-        mockMvc.perform(get(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS + "/7"))
+        mockMvc.perform(get(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS + "/7" + "?idRequester=10"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(jsonPath("$.id", is(7)))
@@ -95,7 +95,7 @@ public class UserControllerTest {
 
     @Test
     void getUserWithNegativeIdFailTest() throws Exception {
-        mockMvc.perform(get(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS + "/-7"))
+        mockMvc.perform(get(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS + "/-7"+"?idRequester=10"))
                 .andExpect(status().isBadRequest())
                 .andDo(mvcResult -> {
                     String content = Objects.requireNonNull(mvcResult.getResolvedException()).getMessage();
@@ -105,7 +105,7 @@ public class UserControllerTest {
 
     @Test
     void getUserWithForNonExistentUserFailTest() throws Exception {
-        mockMvc.perform(get(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS + "/55"))
+        mockMvc.perform(get(UrlUtils.MAIN_URL + UrlUtils.V1 + UrlUtils.USERS + "/55"+"?idRequester=10" ))
                 .andExpect(status().isNotFound())
                 .andDo(mvcResult -> {
                     String content = Objects.requireNonNull(mvcResult.getResolvedException()).getMessage();

--- a/src/test/java/school/faang/user_service/publisher/MentorshipOfferedPublisherTest.java
+++ b/src/test/java/school/faang/user_service/publisher/MentorshipOfferedPublisherTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class MentorshipOfferedMessagePublisherTest {
+public class MentorshipOfferedPublisherTest {
     private static final String TOPIC_NAME = "mentorship-offered-topic";
     @Mock
     private RedisTemplate<String, Object> redisTemplate;

--- a/src/test/java/school/faang/user_service/publisher/ProfileViewPublisherTest.java
+++ b/src/test/java/school/faang/user_service/publisher/ProfileViewPublisherTest.java
@@ -1,0 +1,36 @@
+package school.faang.user_service.publisher;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import school.faang.user_service.dto.ProfileViewEvent;
+import school.faang.user_service.publisher.mentorshipoffered.ProfileViewEventPublisher;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ProfileViewPublisherTest {
+    private static final String TOPIC_NAME = "profile-view-topic";
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+    @Mock
+    private ChannelTopic profileViewTopic;
+    @InjectMocks
+    private ProfileViewEventPublisher profileViewEventPublisher;
+
+    @Test
+    void publishSuccessTest() {
+        ProfileViewEvent profileViewEvent = new ProfileViewEvent(1L, 2L, LocalDateTime.now());
+        when(profileViewTopic.getTopic()).thenReturn(TOPIC_NAME);
+        assertDoesNotThrow(() -> profileViewEventPublisher.publish(profileViewEvent));
+        verify(redisTemplate).convertAndSend(TOPIC_NAME, profileViewEvent);
+    }
+}


### PR DESCRIPTION
Задание
analytics_service должен собирать информацию о просмотрах профиля юзера другими юзерами в user_service:

Создать Spring-конфигурацию Redis топика и реализацию ProfileViewEventPublisher — отправителя события ProfileViewEvent в user_service. Туториал: [PubSub Messaging with Spring Data Redis | Baeldung](https://www.baeldung.com/spring-data-redis-pub-sub)  .

Отправлять событие ProfileViewEvent через ProfileViewEventPublisher в момент, когда пользователь просматривает профиль другого пользователя — вызывает соответствующий эндпоинт. В событии содержатся: id юзера; id юзера, который просматривает; дата и время просмотра.

В analytics_service создать конфигурацию слушателя эвентов ProfileViewEventListener для ProfileViewEvent, руководствуясь тем же тутором выше.

ProfileViewEventListener слушает события ProfileViewEvent и сохраняет информацию из этих событий с БД, используя AnalyticsEventService для выполнения логики сохранения и AnalyticsEvent для превращения ProfileViewEvent в сущность БД. Используем AnalyticsEventMapper для такого превращения.

Критерии приема
Сообщение о новом просмотре профиля отправляется в новый топик Redis из user_service.

Сообщение потребляется из нового топика в Redis в analytics_service.

Данные о событии сохраняются в БД в соответствующую таблицу analytics_event.

Всё покрыто unit-тестами.