### PR TITLE
added jacoco

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,7 @@ tasks {
         violationRules {
             rule {
                 limit {
-                    minimum = 0.8.toBigDecimal()
+                    minimum = 0.7.toBigDecimal()
                 }
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    jacoco
     id("org.springframework.boot") version "3.0.6"
     id("io.spring.dependency-management") version "1.1.0"
     id("org.jsonschema2pojo") version "1.2.1"
@@ -90,6 +91,36 @@ val test by tasks.getting(Test::class) { testLogging.showStandardStreams = true 
 tasks.bootJar {
     archiveFileName.set("service.jar")
 }
+
+tasks {
+    test {
+        useJUnitPlatform()
+        finalizedBy(jacocoTestReport)
+    }
+
+    jacocoTestReport {
+        dependsOn(test)
+
+        reports {
+            xml.required.set(true)
+            html.required.set(true)
+        }
+    }
+
+    jacocoTestCoverageVerification {
+        violationRules {
+            rule {
+                limit {
+                    minimum = 0.8.toBigDecimal()
+                }
+            }
+        }
+    }
+    check {
+        dependsOn(jacocoTestCoverageVerification)
+    }
+}
+
 kotlin {
     jvmToolchain(17)
 }


### PR DESCRIPTION
пред использованием нужно установить Oracle JDK

Для запуска тестов и генерации отчетов:
./gradlew test jacocoTestReport

Для проверки минимального покрытия:
./gradlew check

(сейчас стоит пороговое значение покрытия тестов 80%)

Отчеты будут находиться в папке build/reports/jacoco/test/. Вы найдете там файлы:

index.html — HTML-отчет, который можно открыть в браузере.
report.xml — XML-отчет для использования в других инструментах.

![image](https://github.com/user-attachments/assets/29b4bd99-c38f-4207-a5bb-c0d0d580504e)
