### PR TITLE
fix of mentors and mentees deletion logic

### DIFF
--- a/src/main/java/school/faang/user_service/dto/UserDto.java
+++ b/src/main/java/school/faang/user_service/dto/UserDto.java
@@ -1,4 +1,4 @@
 package school.faang.user_service.dto;
 
-public record UserDto(long id, String name, String email) {
+public record UserDto(Long id, String name, String email) {
 }

--- a/src/main/java/school/faang/user_service/exception/MentorshipNotFoundException.java
+++ b/src/main/java/school/faang/user_service/exception/MentorshipNotFoundException.java
@@ -1,0 +1,7 @@
+package school.faang.user_service.exception;
+
+public class MentorshipNotFoundException extends RuntimeException {
+    public MentorshipNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/school/faang/user_service/repository/mentorship/MentorshipRepository.java
+++ b/src/main/java/school/faang/user_service/repository/mentorship/MentorshipRepository.java
@@ -1,7 +1,6 @@
 package school.faang.user_service.repository.mentorship;
 
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import school.faang.user_service.entity.User;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,12 +15,4 @@ public interface MentorshipRepository extends CrudRepository<User, Long> {
 
     @Query("SELECT m FROM User m JOIN m.mentees u WHERE u.id = :menteeId")
     List<User> findAllMentorsByMenteeId(@Param("menteeId") Long menteeId);
-
-    @Modifying
-    @Query("DELETE FROM mentorship m WHERE m.mentor_id = :mentorId AND m.mentee_id = :menteeId")
-    int deleteMenteeFromMentor(@Param("menteeId") Long menteeId, @Param("mentorId") Long mentorId);
-
-    @Modifying
-    @Query("DELETE FROM mentorship m WHERE m.mentor_id = :mentorId AND m.mentee_id = :menteeId")
-    int deleteMentorFromMentee(@Param("menteeId") Long menteeId, @Param("mentorId") Long mentorId);
 }

--- a/src/main/java/school/faang/user_service/service/MentorshipService.java
+++ b/src/main/java/school/faang/user_service/service/MentorshipService.java
@@ -2,8 +2,10 @@ package school.faang.user_service.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import school.faang.user_service.dto.UserDto;
 import school.faang.user_service.entity.User;
+import school.faang.user_service.exception.MentorshipNotFoundException;
 import school.faang.user_service.mapper.UserMapper;
 import school.faang.user_service.repository.mentorship.MentorshipRepository;
 
@@ -30,18 +32,27 @@ public class MentorshipService {
                 .toList();
     }
 
+    @Transactional
     public void deleteMentee(Long menteeId, Long mentorId) {
-        int deletedRows = mentorshipRepository.deleteMenteeFromMentor(menteeId, mentorId);
-        if (deletedRows == 0) {
-            throw new IllegalArgumentException("No mentorship relationship found to delete");
+        User mentor = mentorshipRepository.findById(mentorId)
+                .orElseThrow(() -> new MentorshipNotFoundException("Mentor not found: " + mentorId));
+        boolean removed = mentor.getMentees().removeIf(mentee -> mentee.getId().equals(menteeId));
+        if (!removed) {
+            throw new MentorshipNotFoundException("No mentorship relationship found for mentor "
+                    + mentorId + " and mentee " + menteeId);
         }
+        mentorshipRepository.save(mentor);
     }
 
+    @Transactional
     public void deleteMentor(Long menteeId, Long mentorId) {
-        int deletedRows = mentorshipRepository.deleteMentorFromMentee(menteeId, mentorId);
-        if (deletedRows == 0) {
-            throw new IllegalArgumentException("No mentorship relationship found to delete");
+        User mentee = mentorshipRepository.findById(menteeId)
+                .orElseThrow(() -> new MentorshipNotFoundException("Mentee not found: " + menteeId));
+        boolean removed = mentee.getMentors().removeIf(mentor -> mentor.getId().equals(mentorId));
+        if (!removed) {
+            throw new MentorshipNotFoundException("No mentorship relationship found for mentee "
+                    + menteeId + " and mentor " + mentorId);
         }
+        mentorshipRepository.save(mentee);
     }
-
 }


### PR DESCRIPTION
1. Added custom Exception 
2. Implemented functionality to retrieve all mentees for a mentor and delete mentorship relationships without using native JPQL delete queries. 
3. Removed the conflicting delete methods from MentorshipRepository and updated MentorshipService to manage the many-to-many associations by loading the User entity, modifying the mentor/mentee collections, and saving changes. 
This approach leverages Hibernate to ensure database-agnostic behavior and better maintainability.

https://faang-school.atlassian.net/browse/BJS2-65878