### PR TITLE
Random avatar feature

### DIFF
--- a/src/main/java/school/faang/user_service/UserServiceApplication.java
+++ b/src/main/java/school/faang/user_service/UserServiceApplication.java
@@ -7,7 +7,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableFeignClients("school.faang.user_service.client")

--- a/src/main/java/school/faang/user_service/UserServiceApplication.java
+++ b/src/main/java/school/faang/user_service/UserServiceApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableFeignClients("school.faang.user_service.client")
@@ -22,5 +23,10 @@ public class UserServiceApplication {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return objectMapper;
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/java/school/faang/user_service/UserServiceApplication.java
+++ b/src/main/java/school/faang/user_service/UserServiceApplication.java
@@ -24,9 +24,4 @@ public class UserServiceApplication {
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return objectMapper;
     }
-
-    @Bean
-    public RestTemplate restTemplate() {
-        return new RestTemplate();
-    }
 }

--- a/src/main/java/school/faang/user_service/config/RestTemplateConfig.java
+++ b/src/main/java/school/faang/user_service/config/RestTemplateConfig.java
@@ -1,0 +1,13 @@
+package school.faang.user_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/school/faang/user_service/controller/avatar/AvatarController.java
+++ b/src/main/java/school/faang/user_service/controller/avatar/AvatarController.java
@@ -3,6 +3,7 @@ package school.faang.user_service.controller.avatar;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -45,7 +46,7 @@ public class AvatarController {
     )
     @ApiResponse(responseCode = "201", description = "Аватар успешно загружен",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = PictureDto.class)))
+                    array = @ArraySchema(schema = @Schema(implementation = PictureDto.class))))
     @ApiResponse(responseCode = "400", description = "Ошибка валидации", content = @Content)
     @Parameter(name = "x-user-id", required = true, in = ParameterIn.HEADER)
     public ResponseEntity<List<PictureDto>> uploadAvatar(@RequestParam("file") MultipartFile file) {
@@ -85,17 +86,21 @@ public class AvatarController {
     @DeleteMapping("/delete")
     @Operation(summary = "Удаление аватара пользователя",
             description = "Удаляет текущий аватар и устанавливает аватар по умолчанию.")
-    @ApiResponse(responseCode = "200", description = "URL нового аватара по умолчанию",
-            content = @Content(mediaType = MediaType.TEXT_PLAIN_VALUE,
-                    schema = @Schema(implementation = String.class)))
+    @ApiResponse(responseCode = "200", description = "Список новых аватаров пользователя",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    array = @ArraySchema(schema = @Schema(implementation = PictureDto.class))))
     @Parameter(name = "x-user-id", required = true, in = ParameterIn.HEADER)
-    public ResponseEntity<String> deleteAvatar() {
+    public ResponseEntity<List<PictureDto>> deleteAvatar() {
         long userId = userContext.getUserId();
         log.info("Received request to delete avatar for user ID: {}", userId);
 
-        String defaultImageUrl = avatarService.deleteAvatar(userId);
+        UserProfilePic defaultRandomAvatar = avatarService.deleteAvatar(userId);
+        List<PictureDto> avatarList = List.of(
+                new PictureDto(defaultRandomAvatar.getFileId(), PictureType.AVATAR_MEDIUM),
+                new PictureDto(defaultRandomAvatar.getSmallFileId(), PictureType.AVATAR_SMALL)
+        );
 
-        log.info("Successfully deleted avatar and set default for user ID: {}. New URL: {}", userId, defaultImageUrl);
-        return ResponseEntity.ok().body(defaultImageUrl);
+        log.info("Successfully deleted avatar and set default for user ID: {}. New URL: {}", userId, avatarList);
+        return ResponseEntity.ok(avatarList);
     }
 }

--- a/src/main/java/school/faang/user_service/service/avatar/AvatarService.java
+++ b/src/main/java/school/faang/user_service/service/avatar/AvatarService.java
@@ -32,8 +32,8 @@ public interface AvatarService {
      * @param userId ID пользователя, чей аватар необходимо скачать.
      * @return Массив байт {@code byte[]}, представляющий изображение аватара в формате PNG.
      * @throws school.faang.user_service.exception.EntityNotFoundException если аватар для пользователя не найден.
-     * @throws DataValidationException если у пользователя установлен аватар по умолчанию, который нельзя скачать.
-     * @throws RuntimeException если произошла ошибка при скачивании файла из S3.
+     * @throws DataValidationException                                     если у пользователя установлен аватар по умолчанию, который нельзя скачать.
+     * @throws RuntimeException                                            если произошла ошибка при скачивании файла из S3.
      */
     byte[] downloadAvatar(long userId);
 

--- a/src/main/java/school/faang/user_service/service/avatar/AvatarService.java
+++ b/src/main/java/school/faang/user_service/service/avatar/AvatarService.java
@@ -32,8 +32,8 @@ public interface AvatarService {
      * @param userId ID пользователя, чей аватар необходимо скачать.
      * @return Массив байт {@code byte[]}, представляющий изображение аватара в формате PNG.
      * @throws school.faang.user_service.exception.EntityNotFoundException если аватар для пользователя не найден.
-     * @throws DataValidationException                                     если у пользователя установлен аватар по умолчанию, который нельзя скачать.
-     * @throws RuntimeException                                            если произошла ошибка при скачивании файла из S3.
+     * @throws DataValidationException если у пользователя установлен аватар по умолчанию, который нельзя скачать.
+     * @throws RuntimeException если произошла ошибка при скачивании файла из S3.
      */
     byte[] downloadAvatar(long userId);
 

--- a/src/main/java/school/faang/user_service/service/avatar/AvatarService.java
+++ b/src/main/java/school/faang/user_service/service/avatar/AvatarService.java
@@ -47,5 +47,5 @@ public interface AvatarService {
      * @param userId ID пользователя, чей аватар необходимо удалить.
      * @return {@code String}, содержащий URL нового аватара по умолчанию.
      */
-    String deleteAvatar(long userId);
+    UserProfilePic deleteAvatar(long userId);
 }

--- a/src/main/java/school/faang/user_service/service/avatar/AvatarServiceImpl.java
+++ b/src/main/java/school/faang/user_service/service/avatar/AvatarServiceImpl.java
@@ -3,7 +3,6 @@ package school.faang.user_service.service.avatar;
 import com.amazonaws.SdkClientException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.retry.annotation.Retryable;
@@ -24,13 +23,9 @@ import school.faang.user_service.service.s3.S3service;
 public class AvatarServiceImpl implements AvatarService {
     private static final long MAX_AVATAR_SIZE = 5 * 1024 * 1024;
 
+    private final RandomAvatarService randomAvatarService;
     private final UserRepository userRepository;
     private final S3service s3service;
-
-    @Value("${avatar.dicebear.base-url}")
-    private String dicebearBaseUrl;
-    @Value("${avatar.dicebear.default-size}")
-    private int dicebearDefaultSize;
 
     @Override
     @Transactional
@@ -85,31 +80,18 @@ public class AvatarServiceImpl implements AvatarService {
 
     @Override
     @Transactional
-    public String deleteAvatar(long userId) {
+    public UserProfilePic deleteAvatar(long userId) {
         log.info("Received request to delete avatar for user ID: {}", userId);
         User user = userRepository.getByIdOrThrow(userId);
         deleteOldAvatarFiles(user);
 
-        String defaultAvatarUrl = String.format(
-                "%s?seed=%s&size=%d",
-                dicebearBaseUrl,
-                user.getUsername(),
-                dicebearDefaultSize
-        );
-        log.info("Generated new default avatar URL for user ID: {}", userId);
-
-        UserProfilePic userProfilePic = user.getUserProfilePic();
-        if (userProfilePic == null) {
-            userProfilePic = new UserProfilePic();
-            log.debug("Creating new UserProfilePic entity for user ID: {} to set default avatar", userId);
-        }
-        userProfilePic.setFileId(defaultAvatarUrl);
-        userProfilePic.setSmallFileId(defaultAvatarUrl);
-        user.setUserProfilePic(userProfilePic);
+        UserProfilePic randomAvatar = randomAvatarService.generateRandomAvatarForUser(user.getUsername());
+        user.setUserProfilePic(randomAvatar);
+        log.info("Generated new random avatar URL for user ID: {}", userId);
 
         userRepository.save(user);
-        log.info("Successfully set default avatar for user ID: {}", userId);
-        return defaultAvatarUrl;
+        log.info("Successfully set random avatar for user ID: {}", userId);
+        return randomAvatar;
     }
 
     @Retryable(retryFor = {SdkClientException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 2))

--- a/src/main/java/school/faang/user_service/service/avatar/RandomAvatarService.java
+++ b/src/main/java/school/faang/user_service/service/avatar/RandomAvatarService.java
@@ -2,8 +2,6 @@ package school.faang.user_service.service.avatar;
 
 import school.faang.user_service.entity.user.UserProfilePic;
 
-import java.util.Map;
-
 /**
  * Сервис для работы с аватарками пользователей.
  * <p>

--- a/src/main/java/school/faang/user_service/service/avatar/RandomAvatarService.java
+++ b/src/main/java/school/faang/user_service/service/avatar/RandomAvatarService.java
@@ -1,0 +1,27 @@
+package school.faang.user_service.service.avatar;
+
+import school.faang.user_service.entity.user.UserProfilePic;
+
+import java.util.Map;
+
+/**
+ * Сервис для работы с аватарками пользователей.
+ * <p>
+ * Позволяет генерировать случайные аватарки через DiceBear API и получать ссылки на разные размеры,
+ * а также удалять аватарки из S3.
+ */
+public interface RandomAvatarService {
+
+    /**
+     * Генерирует случайную аватарку для пользователя и загружает её в Amazon S3.
+     * <p>
+     * Метод создаёт две версии изображения: {@code small} (64x64) и {@code medium} (128x128),
+     * и возвращает ссылки на них. Если генерация или загрузка не удалась после нескольких попыток,
+     * используется fallback-аватарка из статических ресурсов проекта.
+     *
+     * @param username имя пользователя, используется для формирования имени файла в S3 и логирования.
+     * @return карта с ключами "small" и "medium" и значениями — URL соответствующих аватарок.
+     * @throws IllegalStateException если не удалось обработать fallback-аватарку.
+     */
+    UserProfilePic generateRandomAvatarForUser(String username);
+}

--- a/src/main/java/school/faang/user_service/service/avatar/RandomAvatarServiceImpl.java
+++ b/src/main/java/school/faang/user_service/service/avatar/RandomAvatarServiceImpl.java
@@ -1,0 +1,125 @@
+package school.faang.user_service.service.avatar;
+
+import com.amazonaws.SdkClientException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import school.faang.user_service.entity.user.UserProfilePic;
+import school.faang.user_service.service.s3.S3service;
+
+import javax.imageio.ImageIO;
+import java.awt.Image;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RandomAvatarServiceImpl implements RandomAvatarService {
+
+    private final S3service s3service;
+    private final RestTemplate restTemplate;
+
+    @Value("${avatar.dicebear.base-url}")
+    private String dicebearBaseUrl;
+    @Value("${avatar.dicebear.default-size}")
+    private int dicebearDefaultSize;
+
+    private static final int SMALL_SIZE = 64;
+    private static final int BIG_SIZE = 128;
+    private static final int MAX_AVATAR_SIZE_BYTES = 2_000_000;
+
+    @Override
+    public UserProfilePic generateRandomAvatarForUser(String username) {
+        String randomSeed = UUID.randomUUID().toString();
+        try {
+            byte[] avatarBytes = fetchDiceBearAvatar(randomSeed);
+            BufferedImage originalImage = ImageIO.read(new ByteArrayInputStream(avatarBytes));
+            if (originalImage == null) {
+                log.warn("DiceBear returned bytes but ImageIO.read() produced null for seed {}", randomSeed);
+                return serveFallbackAvatar(username);
+            }
+
+            String bigKey = "random-user-avatars/" + username + "/big-" + randomSeed + ".png";
+            String smallKey = "random-user-avatars/" + username + "/small-" + randomSeed + ".png";
+
+            byte[] bigBytes = imageToPngBytes(resizeImage(originalImage, BIG_SIZE));
+            byte[] smallBytes = imageToPngBytes(resizeImage(originalImage, SMALL_SIZE));
+
+            s3service.uploadFileToS3(bigBytes, bigKey);
+            s3service.uploadFileToS3(smallBytes, smallKey);
+
+            UserProfilePic userProfilePic = new UserProfilePic();
+            userProfilePic.setFileId(bigKey);
+            userProfilePic.setSmallFileId(smallKey);
+
+            log.info("Avatars uploaded to S3 for user {}", username);
+            return userProfilePic;
+
+        } catch (Exception e) {
+            log.error("Failed to generate or upload avatars for user {}: {}", username, e.getMessage(), e);
+            return serveFallbackAvatar(username);
+        }
+    }
+
+    @Retryable(
+            retryFor = {RestClientException.class, SdkClientException.class},
+            maxAttempts = 4,
+            backoff = @Backoff(delay = 1000, multiplier = 2))
+    private byte[] fetchDiceBearAvatar(String seed) {
+        String url = String.format("%s?size=%d&seed=%s", dicebearBaseUrl, dicebearDefaultSize, seed);
+        ResponseEntity<byte[]> response = restTemplate.getForEntity(url, byte[].class);
+        byte[] avatarBytes = response.getBody();
+        validateAvatarBytes(avatarBytes, seed);
+        log.info("Random avatar fetched from DiceBear: {}", url);
+        return avatarBytes;
+    }
+
+    private void validateAvatarBytes(byte[] bytes, String seed) {
+        if (bytes == null || bytes.length == 0) {
+            throw new IllegalStateException("Empty avatar from DiceBear for seed " + seed);
+        }
+        if (bytes.length > MAX_AVATAR_SIZE_BYTES) {
+            throw new IllegalStateException("Avatar too large for seed " + seed);
+        }
+    }
+
+    private byte[] imageToPngBytes(BufferedImage image) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", bytes);
+        return bytes.toByteArray();
+    }
+
+    private BufferedImage resizeImage(BufferedImage original, int size) {
+        Image scaled = original.getScaledInstance(size, size, Image.SCALE_SMOOTH);
+        BufferedImage resized = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = resized.createGraphics();
+        g2d.drawImage(scaled, 0, 0, null);
+        g2d.dispose();
+        return resized;
+    }
+
+    private UserProfilePic serveFallbackAvatar(String username) {
+        String fallbackUrl = ServletUriComponentsBuilder.fromCurrentContextPath()
+                .path("/images/default-user-avatar.png")
+                .toUriString();
+
+        UserProfilePic userProfilePic = new UserProfilePic();
+        userProfilePic.setFileId(fallbackUrl);
+        userProfilePic.setSmallFileId(fallbackUrl);
+
+        log.info("Fallback avatars served from static for user {}", username);
+        return userProfilePic;
+    }
+}

--- a/src/main/java/school/faang/user_service/service/user/UserServiceImpl.java
+++ b/src/main/java/school/faang/user_service/service/user/UserServiceImpl.java
@@ -12,25 +12,34 @@ import school.faang.user_service.dto.user.CreateUserDto;
 import school.faang.user_service.dto.user.UpdateUserDto;
 import school.faang.user_service.dto.user.UserDto;
 import school.faang.user_service.entity.user.User;
+import school.faang.user_service.entity.user.UserProfilePic;
 import school.faang.user_service.exception.DataValidationException;
 import school.faang.user_service.exception.ForbiddenException;
 import school.faang.user_service.mapper.UserMapper;
 import school.faang.user_service.repository.user.CountryRepository;
 import school.faang.user_service.repository.user.UserRepository;
+import school.faang.user_service.service.avatar.RandomAvatarService;
+import school.faang.user_service.service.s3.S3service;
+
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
-    @Value("${user.password.min.length}")
-    private int minPasswordLength;
+    private final S3service s3service;
     private final UserRepository userRepository;
     private final CountryRepository countryRepository;
     private final UserMapper userMapper;
     private final UserContext userContext;
+    private final RandomAvatarService randomAvatarService;
     @PersistenceContext
     private EntityManager entityManager;
+
+    @Value("${user.password.min.length}")
+    private int minPasswordLength;
 
     @Transactional
     @Override
@@ -39,6 +48,7 @@ public class UserServiceImpl implements UserService {
         User user = userMapper.toUser(userDto);
         user.setActive(true);
         user.setCountry(countryRepository.getByIdOrThrow(userDto.countryId()));
+        user.setUserProfilePic(randomAvatarService.generateRandomAvatarForUser(userDto.username()));
         user = userRepository.save(user);
         log.info("User {} created", user.getId());
         return userMapper.toUserDto(user);
@@ -49,6 +59,7 @@ public class UserServiceImpl implements UserService {
     public Long delete(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new DataValidationException("User with id " + userId + " not found!"));
+        deleteAvatarIfStoredInS3(user.getUserProfilePic());
         userRepository.delete(user);
         log.info("User {} deleted", user.getId());
         return user.getId();
@@ -56,15 +67,22 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public UserDto update(long userId, UpdateUserDto userDto) {
+    public UserDto update(long userId, UpdateUserDto updateUserDto) {
         long requesterId = userContext.getUserId();
         if (userId != requesterId) {
             throw new ForbiddenException("User " + requesterId + " doesn't match profile owner!");
         }
+
         User user = userRepository.getByIdOrThrow(userId);
-        userMapper.update(userDto, user);
-        user.setCountry(countryRepository.getByIdOrThrow(userDto.countryId()));
+        if (!updateUserDto.username().equals(user.getUsername())) {
+            deleteAvatarIfStoredInS3(user.getUserProfilePic());
+            user.setUserProfilePic(randomAvatarService.generateRandomAvatarForUser(updateUserDto.username()));
+        }
+
+        userMapper.update(updateUserDto, user);
+        user.setCountry(countryRepository.getByIdOrThrow(updateUserDto.countryId()));
         user = userRepository.save(user);
+
         log.info("User {} updated", user.getId());
         return userMapper.toUserDto(user);
     }
@@ -76,6 +94,9 @@ public class UserServiceImpl implements UserService {
         return userMapper.toUserDto(user);
     }
 
+//    ------------------
+//    Private methods
+//    ------------------
     private void createValidation(CreateUserDto userDto, int minPasswordLength) {
         if (userRepository.existsByUsername(userDto.username())) {
             throw new DataValidationException("User with username " + userDto.username() + " already exists!");
@@ -89,5 +110,23 @@ public class UserServiceImpl implements UserService {
         if (userRepository.existsByPhone(userDto.phone())) {
             throw new DataValidationException("User with phone " + userDto.phone() + " already exists!");
         }
+    }
+
+    private void deleteAvatarIfStoredInS3(UserProfilePic pic) {
+        if (pic == null) {
+            return;
+        }
+
+        Stream.of(pic.getFileId(), pic.getSmallFileId())
+                .filter(Objects::nonNull)
+                .filter(id -> !id.startsWith("http"))
+                .forEach(id -> {
+                    try {
+                        s3service.deleteFileFromS3(id);
+                        log.info("Deleted avatar file from S3: {}", id);
+                    } catch (Exception e) {
+                        log.error("Error deleting avatar file {} from S3: ", id, e);
+                    }
+                });
     }
 }

--- a/src/main/java/school/faang/user_service/service/user/UserServiceImpl.java
+++ b/src/main/java/school/faang/user_service/service/user/UserServiceImpl.java
@@ -94,9 +94,6 @@ public class UserServiceImpl implements UserService {
         return userMapper.toUserDto(user);
     }
 
-//    ------------------
-//    Private methods
-//    ------------------
     private void createValidation(CreateUserDto userDto, int minPasswordLength) {
         if (userRepository.existsByUsername(userDto.username())) {
             throw new DataValidationException("User with username " + userDto.username() + " already exists!");

--- a/src/test/java/school/faang/user_service/service/avatar/AvatarServiceImplTest.java
+++ b/src/test/java/school/faang/user_service/service/avatar/AvatarServiceImplTest.java
@@ -9,7 +9,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 import school.faang.user_service.entity.user.User;
 import school.faang.user_service.entity.user.UserProfilePic;
@@ -22,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.anyString;
@@ -33,6 +31,10 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AvatarServiceImplTest {
+
+
+    @Mock
+    private RandomAvatarService randomAvatarService;
 
     @Mock
     private UserRepository userRepository;
@@ -53,8 +55,6 @@ class AvatarServiceImplTest {
         user.setId(userId);
         user.setUsername("testuser");
         file = new MockMultipartFile("file", "test.png", "image/png", new byte[1024]);
-        ReflectionTestUtils.setField(avatarService, "dicebearBaseUrl", "http://test.com");
-        ReflectionTestUtils.setField(avatarService, "dicebearDefaultSize", 256);
     }
 
     @Nested
@@ -129,17 +129,21 @@ class AvatarServiceImplTest {
             UserProfilePic pic = new UserProfilePic();
             pic.setFileId("avatars/1/some-id.png");
             pic.setSmallFileId("avatars/1/some-small-id.png");
+            UserProfilePic randomPic = new UserProfilePic();
+            randomPic.setFileId("random-avatars/1/rand-id.png");
+            randomPic.setSmallFileId("random-avatars/1/rand-small-id.png");
             user.setUserProfilePic(pic);
 
             when(userRepository.getByIdOrThrow(userId)).thenReturn(user);
+            when(randomAvatarService.generateRandomAvatarForUser(user.getUsername())).thenReturn(randomPic);
 
-            final String resultUrl = avatarService.deleteAvatar(userId);
+            final UserProfilePic result = avatarService.deleteAvatar(userId);
 
             verify(s3service, times(1)).deleteFileFromS3("avatars/1/some-id.png");
             verify(s3service, times(1)).deleteFileFromS3("avatars/1/some-small-id.png");
             verify(userRepository, times(1)).save(user);
-            assertTrue(resultUrl.contains("http://test.com"));
-            assertEquals(resultUrl, user.getUserProfilePic().getFileId());
+            assertEquals(result.getFileId(), randomPic.getFileId());
+            assertEquals(result.getSmallFileId(), randomPic.getSmallFileId());
         }
 
         @Test

--- a/src/test/java/school/faang/user_service/service/avatar/RandomAvatarServiceTest.java
+++ b/src/test/java/school/faang/user_service/service/avatar/RandomAvatarServiceTest.java
@@ -16,7 +16,6 @@ import school.faang.user_service.service.s3.S3service;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
@@ -24,7 +23,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RandomAvatarServiceTest {
@@ -68,31 +71,37 @@ class RandomAvatarServiceTest {
 
     @Test
     @DisplayName("Exception when restTemplate return null")
-    void testRestTemplateReturnNull() throws  Exception {
+    void testRestTemplateReturnNull() throws Exception {
         when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
                 .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
 
-        assertThrows(IllegalStateException.class, () -> {service.generateRandomAvatarForUser(username);});
+        assertThrows(IllegalStateException.class, () -> {
+            service.generateRandomAvatarForUser(username);
+        });
         verify(s3service, never()).uploadFileToS3(any(), anyString());
     }
 
     @Test
     @DisplayName("Exception when restTemplate return  empty array")
-    void testRestTemplateReturnEmptyArray() throws Exception{
+    void testRestTemplateReturnEmptyArray() throws Exception {
         when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
                 .thenReturn(new ResponseEntity<>(new byte[0], HttpStatus.OK));
 
-        assertThrows(IllegalStateException.class, () -> {service.generateRandomAvatarForUser(username);});
+        assertThrows(IllegalStateException.class, () -> {
+            service.generateRandomAvatarForUser(username);
+        });
         verify(s3service, never()).uploadFileToS3(any(), anyString());
     }
 
     @Test
     @DisplayName("Exception when restTemplate return too large array")
-    void testRestTemplateReturnLargeArray() throws Exception{
+    void testRestTemplateReturnLargeArray() throws Exception {
         when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
                 .thenReturn(new ResponseEntity<>(new byte[3_000_000], HttpStatus.OK));
 
-        assertThrows(IllegalStateException.class, () -> {service.generateRandomAvatarForUser(username);});
+        assertThrows(IllegalStateException.class, () -> {
+            service.generateRandomAvatarForUser(username);
+        });
         verify(s3service, never()).uploadFileToS3(any(), anyString());
     }
 }

--- a/src/test/java/school/faang/user_service/service/avatar/RandomAvatarServiceTest.java
+++ b/src/test/java/school/faang/user_service/service/avatar/RandomAvatarServiceTest.java
@@ -1,0 +1,98 @@
+package school.faang.user_service.service.avatar;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+import school.faang.user_service.entity.user.UserProfilePic;
+import school.faang.user_service.service.s3.S3service;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RandomAvatarServiceTest {
+    @Mock
+    private S3service s3service;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private RandomAvatarServiceImpl service;
+
+    private String username;
+    private byte[] imageBytes;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        ReflectionTestUtils.setField(service, "dicebearBaseUrl", "http://dicebear-test-png");
+        ReflectionTestUtils.setField(service, "dicebearDefaultSize", 256);
+        username = "Gleb";
+        BufferedImage testImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream bytesStream = new ByteArrayOutputStream();
+        ImageIO.write(testImage, "png", bytesStream);
+        imageBytes = bytesStream.toByteArray();
+    }
+
+    @Test
+    @DisplayName("generateRandomAvatarForUser - success case")
+    void testSuccessfulAvatarGeneration() throws Exception {
+        when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
+                .thenReturn(new ResponseEntity<>(imageBytes, HttpStatus.OK));
+        when(s3service.uploadFileToS3(any(byte[].class), anyString()))
+                .thenReturn("fake-s3-path");
+
+        UserProfilePic profilePic = service.generateRandomAvatarForUser(username);
+
+        assertTrue(profilePic.getFileId().startsWith("random-user-avatars/" + username + "/big-"));
+        assertTrue(profilePic.getSmallFileId().startsWith("random-user-avatars/" + username + "/small-"));
+        verify(s3service, times(2)).uploadFileToS3(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("Exception when restTemplate return null")
+    void testRestTemplateReturnNull() throws  Exception {
+        when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
+                .thenReturn(new ResponseEntity<>(null, HttpStatus.OK));
+
+        assertThrows(IllegalStateException.class, () -> {service.generateRandomAvatarForUser(username);});
+        verify(s3service, never()).uploadFileToS3(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("Exception when restTemplate return  empty array")
+    void testRestTemplateReturnEmptyArray() throws Exception{
+        when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
+                .thenReturn(new ResponseEntity<>(new byte[0], HttpStatus.OK));
+
+        assertThrows(IllegalStateException.class, () -> {service.generateRandomAvatarForUser(username);});
+        verify(s3service, never()).uploadFileToS3(any(), anyString());
+    }
+
+    @Test
+    @DisplayName("Exception when restTemplate return too large array")
+    void testRestTemplateReturnLargeArray() throws Exception{
+        when(restTemplate.getForEntity(anyString(), eq(byte[].class)))
+                .thenReturn(new ResponseEntity<>(new byte[3_000_000], HttpStatus.OK));
+
+        assertThrows(IllegalStateException.class, () -> {service.generateRandomAvatarForUser(username);});
+        verify(s3service, never()).uploadFileToS3(any(), anyString());
+    }
+}


### PR DESCRIPTION
Реализовал генерацию рандомных аватарок для юзеров.

1. Основная логика где задействуется главный [метод](https://github.com/CorporationX/user_service/pull/3522/files#diff-0b891a86fdd1b1284e29ee7a091a4cc19be8affdbc2bde20d8e3c3480dfde8fc) моей фичи, _**генерации случайной аватарки:**_
- При **create user** генерируется случайная автарка.
- Когда происходит **update user**, то только если юзер меняет свой username, то заново генерируется новая аватарка. В остальных случаях она остается такой же. (Сделал именно так, потому что в нашей БД username является UNIQUE и я его использую для уникальной ссылки на аватарку в S3)
- При **delete user** проверяется, если его аватарка была загружена на S3, то сначала она удаляется из бакета. А уже затем удаляется юзер. В ином случае просто удаляется юзер.

2. Правки:
- Раньше когда юзер удалял аватар, который сам и загрузил в свой профиль ([метод тут](https://github.com/CorporationX/user_service/pull/3522/files#diff-59510b2a31f027a9a36258a40dec890338158c488a75f624272db718e292c28d)), то подставлялась дефолтная аватарка, которая физически храниться у нас в проекте. Сейчас же, для лучшего опыта юзера, при удалении своей аватарки, генерируется новая случайная
- Из-за пункта выше, я поправил [AvatarController](https://github.com/CorporationX/user_service/pull/3522/files#diff-6de4984bc8a837a253506e7b20d68d165cd8501b7e7cd5c3c5546a7dcd510f5b)