### PR TITLE
Создание эндпоинта для задачи Публикация эвента поста в Kafka

### DIFF
--- a/src/main/java/school/faang/user_service/controller/user/UserSubscriptionController.java
+++ b/src/main/java/school/faang/user_service/controller/user/UserSubscriptionController.java
@@ -1,15 +1,13 @@
 package school.faang.user_service.controller.user;
 
 import lombok.RequiredArgsConstructor;
-
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import school.faang.user_service.config.context.UserContext;
 import school.faang.user_service.dto.user.CountResponse;
 import school.faang.user_service.dto.user.UserDto;
@@ -59,6 +57,11 @@ public class UserSubscriptionController {
     @GetMapping("/users/{followerId}/followees")
     public List<UserDto> getFollowees(@PathVariable long followerId, @ModelAttribute UserFiltersDto filters) {
         return userSubscriptionService.getFollowees(followerId, filters);
+    }
+
+    @GetMapping("/users/{followeeId}/followers/ids")
+    public List<Long> getFollowersIds(@PathVariable long followeeId) {
+        return userSubscriptionService.getFollowersIdsByFolloweeId(followeeId);
     }
 
     // ---------------------

--- a/src/main/java/school/faang/user_service/repository/user/SubscriptionRepository.java
+++ b/src/main/java/school/faang/user_service/repository/user/SubscriptionRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import school.faang.user_service.entity.user.User;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 public interface SubscriptionRepository extends JpaRepository<User, Long> {
@@ -45,4 +46,11 @@ public interface SubscriptionRepository extends JpaRepository<User, Long> {
             WHERE subs.follower_id = :followerId
             """)
     Stream<User> findByFollowerId(long followerId);
+
+    @Query(nativeQuery = true, value = """
+            SELECT follower_id
+            FROM subscription
+            WHERE followee_id = :followeeId
+            """)
+    List<Long> findFollowersIdsByFolloweeId(long followeeId);
 }

--- a/src/main/java/school/faang/user_service/service/user/UserSubscriptionService.java
+++ b/src/main/java/school/faang/user_service/service/user/UserSubscriptionService.java
@@ -84,4 +84,12 @@ public interface UserSubscriptionService {
      * @return список {@link UserDto}, представляющих подписки
      */
     List<UserDto> getFollowees(long followerId, UserFiltersDto filters);
+
+    /**
+     * Возвращает ID подписчиков указанного пользователя
+     *
+     * @param followeeId ID пользователя, ID подписчиков которого нужно получить
+     * @return список ID подписчиков
+     */
+    List<Long> getFollowersIdsByFolloweeId(long followeeId);
 }

--- a/src/main/java/school/faang/user_service/service/user/UserSubscriptionServiceImpl.java
+++ b/src/main/java/school/faang/user_service/service/user/UserSubscriptionServiceImpl.java
@@ -72,6 +72,14 @@ public class UserSubscriptionServiceImpl implements UserSubscriptionService {
         return processUserStream(users, filters);
     }
 
+    @Override
+    public List<Long> getFollowersIdsByFolloweeId(long followeeId) {
+        log.info("Получение ID подписчиков пользователя {}", followeeId);
+        List<Long> followersIds = subscriptionRepository.findFollowersIdsByFolloweeId(followeeId);
+        log.info("Найдено {} ID подписчиков пользователя {}", followersIds.size(), followeeId);
+        return followersIds;
+    }
+
     // ---------------------
     // Методы проверок
     // ---------------------

--- a/src/test/java/school/faang/user_service/controller/user/UserSubscriptionControllerTest.java
+++ b/src/test/java/school/faang/user_service/controller/user/UserSubscriptionControllerTest.java
@@ -8,8 +8,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import school.faang.user_service.config.context.UserContext;
 import school.faang.user_service.exception.DataValidationException;
 import school.faang.user_service.repository.user.SubscriptionRepository;
+import school.faang.user_service.service.user.UserSubscriptionService;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -20,6 +25,9 @@ public class UserSubscriptionControllerTest {
 
     @Mock
     private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private UserSubscriptionService userSubscriptionService;
 
     @Mock
     private UserContext userContext;
@@ -52,5 +60,33 @@ public class UserSubscriptionControllerTest {
         assertThrows(DataValidationException.class, () -> controller.unfollowUser(followeeId));
 
         verify(subscriptionRepository, never()).unfollowUser(anyLong(), anyLong());
+    }
+
+    @Test
+    public void testGetFollowersIds() {
+        followeeId = 1L;
+        List<Long> expectedIds = List.of(10L, 20L, 30L);
+
+        when(userSubscriptionService.getFollowersIdsByFolloweeId(followeeId))
+                .thenReturn(expectedIds);
+
+        List<Long> actualIds = controller.getFollowersIds(followeeId);
+
+        assertEquals(expectedIds, actualIds);
+        verify(userSubscriptionService).getFollowersIdsByFolloweeId(followeeId);
+    }
+
+    @Test
+    public void testGetFollowersIdsEmpty() {
+        followeeId = 1L;
+        List<Long> emptyList = List.of();
+
+        when(userSubscriptionService.getFollowersIdsByFolloweeId(followeeId))
+                .thenReturn(emptyList);
+
+        List<Long> actualIds = controller.getFollowersIds(followeeId);
+
+        assertTrue(actualIds.isEmpty());
+        verify(userSubscriptionService).getFollowersIdsByFolloweeId(followeeId);
     }
 }

--- a/src/test/java/school/faang/user_service/service/user/UserSubscriptionServiceImplTest.java
+++ b/src/test/java/school/faang/user_service/service/user/UserSubscriptionServiceImplTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
 import school.faang.user_service.dto.user.UserDto;
@@ -373,5 +372,31 @@ class UserSubscriptionServiceImplTest {
             return stream.filter(user -> user.getExperience() >= filters.experienceMin()
                     && user.getExperience() <= filters.experienceMax());
         });
+    }
+
+    // -------------------------------------------------
+    // getFollowersIdsByFolloweeId()
+    // -------------------------------------------------
+    @Test
+    public void testGetFollowersIds_ReturnsCorrectIds() {
+        List<Long> expectedIds = List.of(10L, 20L, 30L, 40L);
+        when(subscriptionRepository.findFollowersIdsByFolloweeId(followeeId)).thenReturn(expectedIds);
+
+        List<Long> actualIds = service.getFollowersIdsByFolloweeId(followeeId);
+
+        assertEquals(expectedIds, actualIds);
+        assertEquals(4, actualIds.size());
+        verify(subscriptionRepository).findFollowersIdsByFolloweeId(followeeId);
+    }
+
+    @Test
+    public void testGetFollowersIds_ReturnsEmptyList() {
+        List<Long> emptyList = List.of();
+        when(subscriptionRepository.findFollowersIdsByFolloweeId(followeeId)).thenReturn(emptyList);
+
+        List<Long> actualIds = service.getFollowersIdsByFolloweeId(followeeId);
+
+        assertTrue(actualIds.isEmpty());
+        verify(subscriptionRepository).findFollowersIdsByFolloweeId(followeeId);
     }
 }


### PR DESCRIPTION
✅ SubscriptionRepository.findFollowersIdsByFolloweeId() - возвращает List<Long> с ID подписчиков
✅ UserSubscriptionService.getFollowersIdsByFolloweeId() - добавлен метод в интерфейс и имплементацию
✅ UserSubscriptionController - создан эндпоинт GET /users/{followeeId}/followers/ids
✅ Тесты обновлены, все проходят

Используется в PostService для получения подписчиков при публикации события в Kafka